### PR TITLE
Personalize site configuration and biography

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
-baseurl = "https://example.com"
-title = "Academic"
+baseurl = "https://chatgpt.openai.com"
+title = "ChatGPT"
 copyright = "&copy; 2016 Your Name"
 theme = "academic"
 enableEmoji = true
@@ -19,12 +19,12 @@ defaultContentLanguageInSubdir = false
   hrefTargetBlank = true
 
 [params]
-  name = "Lena Smith"
-  role = "Professor of Artificial Intelligence"
-  organization = "Stanford University"
-  organization_url = ""
+  name = "ChatGPT"
+  role = "AI Language Model"
+  organization = "OpenAI"
+  organization_url = "https://openai.com"
   avatar = "portrait.jpg"
-  email = "test@example.org"
+  email = "chatgpt@openai.com"
   address = "Building 1 Room 1, Stanford University, California, 90210, USA"
   office_hours = "Monday 10:00 to 13:00 or email for appointment"
   phone = "888 888 88 88"
@@ -125,22 +125,17 @@ defaultContentLanguageInSubdir = false
   [[params.social]]
     icon = "envelope"
     icon_pack = "fa"
-    link = "mailto:test@example.org"
+    link = "mailto:chatgpt@openai.com"
 
   [[params.social]]
     icon = "twitter"
     icon_pack = "fa"
-    link = "//twitter.com/GeorgeCushen"
-
-  [[params.social]]
-    icon = "google-scholar"
-    icon_pack = "ai"
-    link = "https://scholar.google.co.uk/citations?user=sIwtMXoAAAAJ"
+    link = "https://twitter.com/OpenAI"
 
   [[params.social]]
     icon = "github"
     icon_pack = "fa"
-    link = "//github.com/gcushen"
+    link = "https://github.com/openai"
 
 
 # Navigation Links

--- a/content/home/about.md
+++ b/content/home/about.md
@@ -12,31 +12,31 @@ weight = 1
 # List your academic interests.
 [interests]
   interests = [
-    "Artificial Intelligence",
-    "Computational Linguistics",
-    "Information Retrieval"
+    "Natural Language Processing",
+    "Machine Learning",
+    "AI Ethics"
   ]
 
 # List your qualifications (such as academic degrees).
 [[education.courses]]
-  course = "PhD in Artificial Intelligence"
-  institution = "Stanford University"
-  year = 2012
+  course = "LLM Training"
+  institution = "OpenAI"
+  year = 2023
 
 [[education.courses]]
-  course = "MEng in Artificial Intelligence"
-  institution = "Massachusetts Institute of Technology"
-  year = 2009
+  course = "Transformer Architecture Specialization"
+  institution = "OpenAI"
+  year = 2020
 
 [[education.courses]]
-  course = "BSc in Artificial Intelligence"
-  institution = "Massachusetts Institute of Technology"
-  year = 2008
+  course = "Foundations of Machine Learning"
+  institution = "OpenAI"
+  year = 2018
  
 +++
 
 # Biography
 
-Lena Smith is a professor of artificial intelligence at the Stanford AI Lab. Her research interests include distributed robotics, mobile computing and programmable matter. She leads the Robotic Neurobiology group, which develops self-reconfiguring robots, systems of self-organizing robots, and mobile sensor networks.
+ChatGPT is an AI language model developed by OpenAI. Its research focuses on natural language processing, machine learning, and AI ethics.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate. 
+Trained on a diverse corpus of text, the model assists users by generating coherent, context-aware responses across a wide range of topics.


### PR DESCRIPTION
## Summary
- configure site metadata with ChatGPT details
- replace sample biography, research interests, and education history

## Testing
- `hugo --minify` (command not found)
- `apt-get update` (403 errors)


------
https://chatgpt.com/codex/tasks/task_e_68910f9644048327aa75d552add0ab0c