### PR TITLE
Update about page with current role and interests

### DIFF
--- a/content/home/about.md
+++ b/content/home/about.md
@@ -12,31 +12,13 @@ weight = 1
 # List your academic interests.
 [interests]
   interests = [
-    "Artificial Intelligence",
-    "Computational Linguistics",
-    "Information Retrieval"
+    "Machine Learning",
+    "Medical Imaging",
+    "Computer Vision"
   ]
-
-# List your qualifications (such as academic degrees).
-[[education.courses]]
-  course = "PhD in Artificial Intelligence"
-  institution = "Stanford University"
-  year = 2012
-
-[[education.courses]]
-  course = "MEng in Artificial Intelligence"
-  institution = "Massachusetts Institute of Technology"
-  year = 2009
-
-[[education.courses]]
-  course = "BSc in Artificial Intelligence"
-  institution = "Massachusetts Institute of Technology"
-  year = 2008
  
 +++
 
 # Biography
 
-Lena Smith is a professor of artificial intelligence at the Stanford AI Lab. Her research interests include distributed robotics, mobile computing and programmable matter. She leads the Robotic Neurobiology group, which develops self-reconfiguring robots, systems of self-organizing robots, and mobile sensor networks.
-
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate. 
+Ahmed Tahseen Minhaz is a Data Scientist at Philips IGT-D in Plymouth, Minnesota, where he develops data-driven solutions for image-guided therapy devices. His research interests include machine learning, medical image analysis, and computer vision.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="theme" content="hugo-academic">
   <meta name="generator" content="Hugo 0.21" />
   <meta name="author" content="Ahmed Tahseen Minhaz">
-  <meta name="description" content="Postdoctoral Fellow at Cleveland Clinic">
+  <meta name="description" content="Data Scientist at Philips IGT-D">
 
   
   
@@ -145,11 +145,11 @@
 
       <div class="portrait-title">
         <h2 itemprop="name">Ahmed Tahseen Minhaz</h2>
-        <h3 itemprop="jobTitle">Postdoctoral Fellow</h3>
-        
+        <h3 itemprop="jobTitle">Data Scientist</h3>
+
         <h3 itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">
-          <a href="https://www.lerner.ccf.org/" target="_blank" itemprop="url">
-            <span itemprop="name">Lerner Research Institute, Cleveland Clinic</span>
+          <a href="https://www.philips.com" target="_blank" itemprop="url">
+            <span itemprop="name">Philips Image Guided Therapy Devices (IGT-D), Plymouth, MN</span>
           </a>
         </h3>
         
@@ -197,9 +197,7 @@
 
 <h1 id="about-me">About Me</h1>
 
-<p>I am currently a Postdoctoral Fellow at the Lerner Research Institute in Cleveland Clinic, working in <a href="https://www.lerner.ccf.org/biomedical-engineering/li/">Dr. Xiaojuan Li</a> and <a href="https://www.lerner.ccf.org/biomedical-engineering/nakamura/">Dr. Kunio Nakamura</a>'s lab. Prior to that, I completed my PhD under <a href="https://case.edu/bme/people/primary-faculty/david-l-wilson">Dr. David L. Wilson</a>'s supervision at Case Western Reserve University. My research spans real-world problems related to the applications of machine learning, computer vision and signal processing.</p>
-
-<p> Previously, I worked as a computer vision researcher at Semion Inc. I completed my Bachelors and Masters degree in Electrical and Electronic Engineering from Bangladesh University of Engineering and Technology, where I was advised by <a href="https://www.celiashahnaz.com/">Dr. Celia Shahnaz</a>.
+  <p>I am a Data Scientist at Philips Image Guided Therapy Devices (IGT-D) in Plymouth, Minnesota, where I develop data-driven solutions for image-guided therapy. My research interests include machine learning, medical image analysis, and computer vision.</p>
 
 <p>
   Please check my updated <a href="/Ahmed Tahseen Minhaz CV.docx">CV</a> and <a href="/Ahmed Tahseen Minhaz Resume.docx">resume</a>.
@@ -468,7 +466,7 @@
       
       <li>
         <i class="fa-li fa fa-map-marker fa-2x" aria-hidden="true"></i>
-        <span id="person-address" itemprop="address">Cleveland, USA</span>
+        <span id="person-address" itemprop="address">Plymouth, MN, USA</span>
       </li>
       
 


### PR DESCRIPTION
## Summary
- update about page with current role at Philips IGT-D and revised research interests
- remove placeholder education info
- update generated homepage to reflect new biography and address

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689110b8a498832798fc7b4399771e06