### PR TITLE
Handle publications without categories

### DIFF
--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -26,6 +26,17 @@ author_profile: true
       {% include archive-single.html %}
     {% endfor %}
   {% endfor %}
+  {% assign other_title_shown = false %}
+  {% for post in site.publications reversed %}
+    {% if post.category %}
+      {% continue %}
+    {% endif %}
+    {% unless other_title_shown %}
+      <h2>Other Publications</h2><hr />
+      {% assign other_title_shown = true %}
+    {% endunless %}
+    {% include archive-single.html %}
+  {% endfor %}
 {% else %}
   {% for post in site.publications reversed %}
     {% include archive-single.html %}


### PR DESCRIPTION
## Summary
- Show publications even when no category is assigned

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689230dfab048327ba221b28f4413943